### PR TITLE
fix: Corrigir erro no lançamento da exception #29

### DIFF
--- a/rn/MdWsSeiProcedimentoRN.php
+++ b/rn/MdWsSeiProcedimentoRN.php
@@ -1440,7 +1440,7 @@ class MdWsSeiProcedimentoRN extends InfraRN
             /** Chamando serviço para retorno das ciencias do processo **/
             $arrDadosCiencias = MdWsSeiRest::dataToIso88591($this->listarCienciaProcesso($procedimentoHistoricoDTO));
             if(!$arrDadosCiencias['sucesso']){
-                throw new Exception($arrDadosCiencias['mensagem'], $arrDadosCiencias['exception']);
+                throw new Exception($arrDadosCiencias['mensagem'], 0, $arrDadosCiencias['exception']);
             }
 
             $arrCiencias = $arrDadosCiencias['data'];


### PR DESCRIPTION
Quando o retorno do endpoint _processo/lista_ não retornava sucesso por qualquer motivo, era lançado uma exceção,
Porem passagem de parâmetros na exception estava sendo passado de forma incorreta, ocasionando um **Fatal Error**

closes(#29)