### PR TITLE
HTML do conteúdo do documento em Base64

### DIFF
--- a/src/MdWsSeiRest.php
+++ b/src/MdWsSeiRest.php
@@ -77,7 +77,7 @@ class MdWsSeiRest extends SeiIntegracao
      * @param bool $jsonEncode - Se alterado para true retornará como json_encode
      * @return array
      */
-    public static function formataRetornoSucessoREST($mensagem = null, $result = null, $total = null, $jsonEncode = false)
+    public static function formataRetornoSucessoREST($mensagem = null, $result = null, $total = null, $jsonEncode = false, $base64Encode = false)
     {
         $data = array();
         $data['sucesso'] = true;
@@ -90,6 +90,10 @@ class MdWsSeiRest extends SeiIntegracao
         if (!is_null($total)) {
             $data['total'] = $total;
         }
+        if($base64Encode){
+            $data['data'] = base64_encode($result);
+        }
+
         $retorno = MdWsSeiRest::dataToUtf8($data);
 
         return !$jsonEncode ? $retorno : json_encode($retorno);

--- a/src/rn/MdWsSeiDocumentoRN.php
+++ b/src/rn/MdWsSeiDocumentoRN.php
@@ -108,7 +108,7 @@ class MdWsSeiDocumentoRN extends DocumentoRN
                 $auditoriaProtocoloRN->auditarVisualizacao($auditoriaProtocoloDTO);
             }
 
-            return MdWsSeiRest::formataRetornoSucessoREST(null, $result);
+            return MdWsSeiRest::formataRetornoSucessoREST(null, $result, null, false, true);
         }catch (Exception $e){
             LogSEI::getInstance()->gravar(InfraException::inspecionar($e));
             return MdWsSeiRest::formataRetornoErroREST($e);


### PR DESCRIPTION
O endpoint GET /documento/interno/visualizar estava retornando o HTML do conteúdo do documento de forma incorreta. O método formataRetornoSucessoREST foi alterado para codificar o HTML em base64 antes de retornar o JSON